### PR TITLE
Fix chi missing values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * [`{glue}`](https://glue.tidyverse.org/) is no longer a dependency as the required functionality can be provided by [`stringr::str_glue()](https://stringr.tidyverse.org/reference/str_glue.html).
 * Dependency versions have been updated to the latest.
+* `get_chi()` and `get_anon_chi()` now properly match missing (`NA`) and blank (`""`) values.
 
 # slfhelper 0.9.0
 

--- a/R/get_anon_chi.R
+++ b/R/get_anon_chi.R
@@ -54,7 +54,7 @@ get_anon_chi <- function(chi_cohort, chi_var = "chi", drop = TRUE, check = TRUE)
   lookup <- tibble::tibble(
     chi = unique(chi_cohort[[chi_var]])
   ) %>%
-    dplyr::mutate(anon_chi = purrr::map_chr(.data$chi, openssl::base64_encode))
+    dplyr::mutate(anon_chi = convert_chi_to_anon_chi(.data$chi))
 
   chi_cohort <- chi_cohort %>%
     dplyr::left_join(
@@ -69,4 +69,17 @@ get_anon_chi <- function(chi_cohort, chi_var = "chi", drop = TRUE, check = TRUE)
   }
 
   return(chi_cohort)
+}
+
+convert_chi_to_anon_chi <- function(chi) {
+  anon_chi <- purrr::map_chr(
+    chi,
+    ~ dplyr::case_match(.x,
+      NA_character_ ~ NA_character_,
+      "" ~ "",
+      .default = openssl::base64_encode(.x)
+    )
+  )
+
+  return(anon_chi)
 }

--- a/R/get_chi.R
+++ b/R/get_chi.R
@@ -19,7 +19,7 @@ get_chi <- function(data, anon_chi_var = "anon_chi", drop = TRUE) {
   lookup <- tibble::tibble(
     anon_chi = unique(data[[anon_chi_var]])
   ) %>%
-    dplyr::mutate(chi = unname(convert_anon_chi_to_chi(.data$anon_chi)))
+    dplyr::mutate(chi = convert_anon_chi_to_chi(.data$anon_chi))
 
   data <- data %>%
     dplyr::left_join(
@@ -36,10 +36,17 @@ get_chi <- function(data, anon_chi_var = "anon_chi", drop = TRUE) {
   return(data)
 }
 
-convert_anon_chi_to_chi <- Vectorize(function(anon_chi) {
-  chi <- openssl::base64_decode(anon_chi) %>%
-    substr(2, 2) %>%
-    paste0(collapse = "")
+convert_anon_chi_to_chi <- function(anon_chi) {
+  chi <- purrr::map_chr(
+    anon_chi,
+    ~ dplyr::case_match(.x,
+      NA_character_ ~ NA_character_,
+      "" ~ "",
+      .default = openssl::base64_decode(.x) %>%
+        substr(2, 2) %>%
+        paste0(collapse = "")
+    )
+  )
 
   return(chi)
-})
+}

--- a/tests/testthat/_snaps/get_anon_chi.md
+++ b/tests/testthat/_snaps/get_anon_chi.md
@@ -1,0 +1,22 @@
+# Missing or blank CHIs match correctly
+
+    Code
+      get_anon_chi(data)
+    Output
+      # A tibble: 2 x 1
+        anon_chi
+        <chr>   
+      1 ""      
+      2 <NA>    
+
+---
+
+    Code
+      get_anon_chi(data, drop = FALSE)
+    Output
+      # A tibble: 2 x 2
+        chi   anon_chi
+        <chr> <chr>   
+      1 ""    ""      
+      2 <NA>  <NA>    
+

--- a/tests/testthat/_snaps/get_chi.md
+++ b/tests/testthat/_snaps/get_chi.md
@@ -1,38 +1,42 @@
 # Can get CHI numbers for an arbitrary set of anon_chi numbers
 
     Code
-      .
+      get_chi(data)
     Output
-      # A tibble: 10 x 1
-         chi       
-         <chr>     
-       1 2601211618
-       2 2210680631
-       3 1410920754
-       4 3112358158
-       5 0112418156
-       6 0612732243
-       7 2310474015
-       8 2411063698
-       9 3801112374
-      10 2311161233
+      # A tibble: 12 x 1
+         chi         
+         <chr>       
+       1 "2601211618"
+       2 "2210680631"
+       3 "1410920754"
+       4 "3112358158"
+       5 "0112418156"
+       6 "0612732243"
+       7 "2310474015"
+       8 "2411063698"
+       9 "3801112374"
+      10 "2311161233"
+      11 ""          
+      12  <NA>       
 
 ---
 
     Code
-      .
+      get_chi(data, drop = FALSE)
     Output
-      # A tibble: 10 x 2
-         anon_chi         chi       
-         <chr>            <chr>     
-       1 MjYwMTIxMTYxOA== 2601211618
-       2 MjIxMDY4MDYzMQ== 2210680631
-       3 MTQxMDkyMDc1NA== 1410920754
-       4 MzExMjM1ODE1OA== 3112358158
-       5 MDExMjQxODE1Ng== 0112418156
-       6 MDYxMjczMjI0Mw== 0612732243
-       7 MjMxMDQ3NDAxNQ== 2310474015
-       8 MjQxMTA2MzY5OA== 2411063698
-       9 MzgwMTExMjM3NA== 3801112374
-      10 MjMxMTE2MTIzMw== 2311161233
+      # A tibble: 12 x 2
+         anon_chi           chi         
+         <chr>              <chr>       
+       1 "MjYwMTIxMTYxOA==" "2601211618"
+       2 "MjIxMDY4MDYzMQ==" "2210680631"
+       3 "MTQxMDkyMDc1NA==" "1410920754"
+       4 "MzExMjM1ODE1OA==" "3112358158"
+       5 "MDExMjQxODE1Ng==" "0112418156"
+       6 "MDYxMjczMjI0Mw==" "0612732243"
+       7 "MjMxMDQ3NDAxNQ==" "2310474015"
+       8 "MjQxMTA2MzY5OA==" "2411063698"
+       9 "MzgwMTExMjM3NA==" "3801112374"
+      10 "MjMxMTE2MTIzMw==" "2311161233"
+      11 ""                 ""          
+      12  <NA>               <NA>       
 

--- a/tests/testthat/test-get_anon_chi.R
+++ b/tests/testthat/test-get_anon_chi.R
@@ -15,3 +15,10 @@ test_that("Matching with a different name works", {
   expect_equal(nrow(cohort_with_anon), nrow(chi_cohort))
   expect_equal(length(cohort_with_anon), length(chi_cohort))
 })
+
+test_that("Missing or blank CHIs match correctly", {
+  data <- tibble::tibble(chi = c("", NA_character_))
+
+  expect_snapshot(get_anon_chi(data))
+  expect_snapshot(get_anon_chi(data, drop = FALSE))
+})

--- a/tests/testthat/test-get_chi.R
+++ b/tests/testthat/test-get_chi.R
@@ -10,17 +10,15 @@ test_that("Can get CHI numbers for an arbitrary set of anon_chi numbers", {
       "MjMxMDQ3NDAxNQ==",
       "MjQxMTA2MzY5OA==",
       "MzgwMTExMjM3NA==",
-      "MjMxMTE2MTIzMw=="
+      "MjMxMTE2MTIzMw==",
+      "",
+      NA_character_
     )
   )
 
-  data %>%
-    get_chi() %>%
-    expect_snapshot()
+  expect_snapshot(get_chi(data))
 
-  data %>%
-    get_chi(drop = FALSE) %>%
-    expect_snapshot()
+  expect_snapshot(get_chi(data, drop = FALSE))
 })
 
 skip_on_ci()


### PR DESCRIPTION
`get_chi()` and `get_anon_chi()` now properly match missing (`NA`) and blank (`""`) values.

Fixes an issue identified in https://github.com/Public-Health-Scotland/source-linkage-files/pull/752