### PR TITLE
Update render-README.yaml

### DIFF
--- a/.github/workflows/render-README.yaml
+++ b/.github/workflows/render-README.yaml
@@ -13,7 +13,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -33,20 +33,7 @@ jobs:
       - name: Render README.Rmd
         run:  Rscript -e 'rmarkdown::render("README.Rmd")'
 
-      - name: Commit and create a Pull Request on production
-        if: ${{ github.ref == 'refs/heads/production' }}
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: "Render `README.md` after changes to the `.Rmd` version"
-          branch: render_readme
-          delete-branch: true
-          title: "Render `README.md` after changes to the `.Rmd` version"
-          labels: documentation,Maintainance
-          assignees: ${{ github.actor }}
-          reviewers: ${{ github.actor }}
-
-      - name: Commit and push changes on all other branches
-        if: ${{ github.ref != 'refs/heads/production' }}
-        uses: stefanzweifel/git-auto-commit-action@v6
+      - name: Commit and push changes
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "Render `README.md` after changes to the `.Rmd` version"


### PR DESCRIPTION
Made changes to use stefanzweifel workflow for commit to both production and other branches rather than the former logic that uses peter-evans/create-pull-request@v7 for commits and PR on production and stefanzweifel/git-auto-commit-action@v6 for other branches. 

This is to fix the error 128 detached HEAD that occurs when we merge other branches to production.